### PR TITLE
docs(adr): add ADR-001 ledger balance, ADR-002 daily interest, ADR-00…

### DIFF
--- a/docs/adr/ADR-001-solde-par-grand-livre.md
+++ b/docs/adr/ADR-001-solde-par-grand-livre.md
@@ -1,0 +1,91 @@
+# ADR-001 — Stratégie de solde par grand livre (ledger)
+
+- **Statut** : Accepté
+- **Date** : 2025-09-14
+- **Contexte**  
+  Le sujet impose : _« Solde = Σ crédits − Σ débits »_ et des virements atomiques. On veut une base **auditable**, **simple à tester**, et **indépendante** des frameworks.  
+  Le domaine contient `Account`, `Operation(kind=DEBIT|CREDIT)`, `Money`, et des Use Cases (ex. `InternalTransfer`).
+
+## Décision
+
+1. **Solde dérivé du grand livre** : l’état source de vérité est la table `operations` (écritures immuables).  
+   Le solde d’un compte = somme des **CREDIT** − somme des **DEBIT**.
+2. **Opérations immuables** : aucune mise à jour/suppression ; seules des écritures compensatoires (storno) sont autorisées.
+3. **Dénormalisation facultative** : un champ `accounts.balance_cents` peut être maintenu **en cache** (vu performance), mais le **ledger reste l’autorité**.
+4. **Monnaie** : stockage en **centimes (entiers)**, `EUR` comme devise unique.
+
+## Modèle (SQL indicatif)
+
+```sql
+create table accounts (
+  id                  uuid primary key,
+  owner_id            uuid not null,
+  iban                text unique not null,
+  type                text not null check (type in ('CURRENT','SAVINGS')),
+  name                text not null,
+  status              text not null default 'ACTIVE',
+  balance_cents       bigint not null default 0, -- dénormalisation facultative
+  currency            char(3) not null default 'EUR',
+  created_at          timestamptz not null default now()
+);
+
+create table operations (
+  id                  uuid primary key,
+  account_id          uuid not null references accounts(id),
+  kind                text not null check (kind in ('DEBIT','CREDIT')),
+  amount_cents        bigint not null check (amount_cents > 0),
+  currency            char(3) not null default 'EUR',
+  meta                jsonb not null default '{}'::jsonb, -- transfer_id, order_id, etc.
+  created_at          timestamptz not null default now()
+);
+
+create index idx_ops_account_created_at on operations(account_id, created_at);
+```
+
+## Calcul du solde
+
+- **Autoritaire** (requête) :
+
+  ```sql
+  select coalesce(sum(case when kind='CREDIT' then amount_cents else -amount_cents end),0) as balance_cents
+  from operations where account_id = $1;
+  ```
+
+- **Dénormalisé** (maintenu en transaction) : à chaque écriture, on ajuste `accounts.balance_cents`.
+  En cas d’écart (rare), on recalcule depuis `operations`.
+
+## Invariants & règles
+
+- Montants strictement **positifs** ; aucune opération 0 ou négative.
+- Mono-devise (EUR) ; conversions interdites dans V1.
+- Aucune écriture sans lien métier (`meta` doit tracer l’origine : transfer_id, interest_id, …).
+- **Cohérence** : pour un virement interne, on crée 2 écritures dans une **même transaction** :
+  - DEBIT du compte source,
+  - CREDIT du compte cible.
+
+## Exemple (virement 12€)
+
+- `op1` : DEBIT 1200 (compte A)
+- `op2` : CREDIT 1200 (compte B)
+
+## Cas limites
+
+- **Compte bloqué** ⇒ refus d’écriture.
+- **Découvert** : non autorisé (v1) ⇒ refuser si `solde < montant`.
+- **Même compte source=dest** ⇒ refuser (sans effet).
+
+## Tests (exemples)
+
+- Création 3 crédits et 2 débits ⇒ solde attendu = ΣC − ΣD.
+- Virement : après transaction, somme des soldes globaux **inchangée**.
+- Refus si solde insuffisant (aucune écriture créée).
+
+## Alternatives étudiées (rejetées)
+
+- Stocker uniquement un champ `balance` mutable (perte d’audit) → ❌
+- Double-entrée stricte (comptabilité générale) → surdimensionné pour V1.
+
+## Impacts
+
+- Requêtes solde faciles ; batch de réconciliation possible (script).
+- Migration ultérieure vers Event Sourcing facilitée (ledger déjà en place).

--- a/docs/adr/ADR-002-interets-quotidiens-epargne.md
+++ b/docs/adr/ADR-002-interets-quotidiens-epargne.md
@@ -1,0 +1,92 @@
+# ADR-002 — Rémunération quotidienne des comptes épargne
+
+- **Statut** : Accepté
+- **Date** : 2025-09-14
+- **Contexte**  
+  Le sujet impose une **rémunération quotidienne** au **taux en vigueur** fixé par l’administrateur, avec **notification** lors d’un changement. On doit spécifier le calcul, l’arrondi et l’instant d’application.
+
+## Décision
+
+1. **Base de calcul** : ACT/365 simple (pas bissextile-spécifique en V1).  
+   Taux journalier = `taux_annuel / 365`.
+2. **Instant** : les intérêts du jour **J** sont calculés à **J+1 00:05 Europe/Paris** sur le **solde de clôture de J** (après toutes écritures de J).
+3. **Arrondi** : calcul en **centimes** avec arrondi **au centime supérieur si ≥ 0.5** (half up).
+4. **Idempotence du job** : une seule application par (account_id, date).
+5. **Changement de taux** : `SavingsRate(value, effectiveFrom)` — le taux **en vigueur** pour le jour J est le dernier taux dont `effectiveFrom ≤ J 00:00:00`. Une **notification** est envoyée à chaque détenteur lors de l’update.
+
+## Schéma & tables
+
+```sql
+create table savings_rates (
+  id uuid primary key,
+  value_bps integer not null,  -- base points: 1% = 100 bps
+  effective_from date not null -- prise d'effet 00:00 Europe/Paris
+);
+
+create table daily_interest (
+  id uuid primary key,
+  account_id uuid not null references accounts(id),
+  day date not null, -- jour rémunéré
+  rate_bps integer not null,
+  interest_cents bigint not null check (interest_cents >= 0),
+  created_at timestamptz not null default now(),
+  unique (account_id, day)
+);
+```
+
+## Formules
+
+- `taux_journalier (d)` = `rate_bps(d) / 100 / 365`
+- `interet_cents (d)` = `round_half_up( balance_cents_J * rate_bps / (365*100) )`
+
+> On évite les flottants : on manipule des entiers (centimes, bps).
+
+## Algorithme (pseudocode)
+
+```ts
+for each savingsAccount as a:
+  const d = today - 1 (Europe/Paris)
+  if daily_interest.exists(a.id, d) return // idempotent
+  const rate = getRateAt(d) // last rate with effectiveFrom <= d
+  const balance = getClosingBalanceCents(a.id, d)
+  const interest = roundHalfUp(balance * rate.bps / (365*100))
+  if (interest > 0) {
+    // écriture CREDIT sur le ledger épargne
+    createOperation(a.id, 'CREDIT', interest, { kind: 'DAILY_INTEREST', day: d })
+  }
+  insert daily_interest(a.id, d, rate.bps, interest)
+```
+
+## Changement de taux & notification
+
+- Route admin : `POST /admin/savings-rate { valuePercent }`
+- Écrit `savings_rates(effective_from = today)` et **publie** `Notification{ userId, type:'SAVINGS_RATE_CHANGED', payload:{value} }`.
+- **Effet** sur calcul : **dès le lendemain** (J+1).
+
+## Exemples
+
+- Solde 10 000€ (1 000 000 cents), taux 3.00% (300 bps)
+  `interest = round(1_000_000 * 300 / 36_500) = round(8.219…) = 8 cents` par jour.
+- Taux modifié à 3.20% le 10/10 → rémunération à **3.20% dès le 11/10**.
+
+## Cas limites
+
+- Solde négatif (non autorisé en épargne) → aucun intérêt.
+- Compte fermé le jour J → pas de rémunération pour J+1.
+- Changement de taux multiple le même jour → on conserve le **dernier** `effectiveFrom ≤ J`.
+
+## Tests attendus
+
+- Taux constant sur une semaine : somme(J) conforme.
+- Taux changeant : bascule au bon jour.
+- Idempotence : 2 exécutions du job pour (account, J) ne doublent pas l’intérêt.
+
+## Alternatives (rejetées)
+
+- ACT/360 → plus agressif, non justifié ici.
+- Intérêts intrajournaliers → surcomplexifie les règles.
+
+## Impacts
+
+- Job planifié (cron 00:05 Europe/Paris).
+- Nécessite un **Notifier adapter** (mock en S3, provider plus tard).

--- a/docs/adr/ADR-003-virements-idempotents.md
+++ b/docs/adr/ADR-003-virements-idempotents.md
@@ -1,0 +1,117 @@
+# ADR-003 — Virements internes idempotents
+
+- **Statut** : Accepté
+- **Date** : 2025-09-14
+- **Contexte**  
+  Les virements sont **internes à la banque**. On doit garantir l’**atomicité** (tout ou rien) et l’**idempotence** (pas d’effet doublé lors de retries). Le client peut réessayer en cas de réseau.
+
+## Décision
+
+1. **Idempotency-Key obligatoire** : chaque appel `POST /transfers` doit porter un `Idempotency-Key: <uuid-v4>`.
+2. **Clé portée par la table des transferts** avec **contrainte unique** :
+   - **Scope** = `(from_account_id, idempotency_key)` — un retry du même client réutilise la clé.
+3. **Transaction SQL** : on crée **DEBIT** puis **CREDIT** dans `operations` + on persiste un `internal_transfers` **dans la même transaction**.
+4. **Isolation** : `SERIALIZABLE` (ou `REPEATABLE READ` + verrous explicites) + `SELECT ... FOR UPDATE` sur les 2 comptes (ordre stable par `uuid` pour éviter les deadlocks).
+5. **Réponse idempotente** : si une ligne existe déjà avec la même clé → on renvoie **le même body** (201) sans dupliquer les écritures.
+
+## Modèle (SQL indicatif)
+
+```sql
+create table internal_transfers (
+  id uuid primary key,
+  idempotency_key uuid not null,
+  from_account_id uuid not null references accounts(id),
+  to_account_id   uuid not null references accounts(id),
+  amount_cents    bigint not null check (amount_cents > 0),
+  currency        char(3) not null default 'EUR',
+  status          text not null default 'SUCCEEDED',
+  created_at      timestamptz not null default now(),
+  unique (from_account_id, idempotency_key)
+);
+```
+
+## Algorithme (pseudocode)
+
+```ts
+function internalTransfer(cmd){
+  // Validations préalables
+  assert cmd.amount_cents > 0
+  assert cmd.from !== cmd.to
+  assert accounts.currency === 'EUR'
+  // Début transaction
+  begin
+    // idempotence
+    if exists transfer where from=cmd.from and key=cmd.key:
+      return 201, transfer_cached_response
+
+    // Verrouiller comptes dans un ordre stable
+    const [a, b] = sortById([cmd.from, cmd.to])
+    select * from accounts where id in (a,b) for update
+
+    // Solde suffisant
+    if closing_balance(cmd.from) < cmd.amount_cents:
+      rollback; return 422 'insufficient_funds'
+
+    // Ledger
+    insert operations(DEBIT, from, amount)
+    insert operations(CREDIT, to, amount)
+
+    // Dénormalisation (facultatif)
+    update accounts set balance_cents = balance_cents - amount where id=from
+    update accounts set balance_cents = balance_cents + amount where id=to
+
+    // Trace idempotence
+    insert internal_transfers(id, key, from, to, amount)
+
+  commit
+  return 201 { transferId, from, to, amount }
+}
+```
+
+## Contrat d’API (exemple)
+
+`POST /transfers`
+
+```json
+{
+  "fromAccountId": "uuid",
+  "toAccountId": "uuid",
+  "amount": 12500
+}
+```
+
+Headers : `Idempotency-Key: 9f7f3d5a-...`
+Réponses :
+
+- **201** `{id, fromAccountId, toAccountId, amount}` (créé ou **rejoué**)
+- **422** `{"error":"insufficient_funds"}`
+- **400** `{"error":"invalid_request"}`
+- **409** si conflit de verrou / réessayer
+
+## Sécurité & erreurs
+
+- Rejeter toute **idempotency-key vide** / non UUID.
+- **Window** : on garde les clés 24h (paramétrable).
+- **Timeout** : si la transaction n’aboutit pas, on n’écrit **rien** (atomique).
+
+## Observabilité
+
+- Logger `transfer_id`, `idempotency_key`, `from`, `to`, `amount_cents`, `duration_ms`.
+- Métriques : taux d’échec, conflits, retries, latence p95/p99.
+
+## Tests
+
+- Deux POST identiques avec même `Idempotency-Key` ⇒ **1 seul** DEBIT/CREDIT.
+- POST sans clé ⇒ **400**.
+- Solde insuffisant ⇒ **422** (aucune écriture).
+- Concurrence : 2 transferts simultanés du même compte ⇒ l’un échoue proprement (verrouillage).
+
+## Alternatives (rejetées)
+
+- Idempotence par hash du corps sans clé explicite → fragile si horodatage/ordre change.
+- Verrouillage applicatif uniquement → préférer des verrous DB pour la cohérence.
+
+## Impacts
+
+- Une table `internal_transfers` + index.
+- Charges de concurrence maîtrisées ; retry client **sûr**.


### PR DESCRIPTION
## Objectif

Documenter les décisions d’architecture de référence pour le projet MonAvenirBank.  
Ces ADR clarifient les règles de calcul du solde, la rémunération quotidienne des comptes épargne et l’idempotence des virements internes.  

## Changements

- Ajout de `ADR-001` : Stratégie de solde par grand livre (ledger)
- Ajout de `ADR-002` : Intérêts journaliers (calcul, arrondi, idempotence du job)
- Ajout de `ADR-003` : Virements internes idempotents (clé, transaction SQL)

## Tests

- [ ] Unit tests (Domain / Application) — N/A (docs seulement)
- [ ] Intégration (adapters/infra) — N/A
- [ ] E2E/API (si impact) — N/A
- [x] Manuels : lecture/validation des ADR par l’équipe

## Impacts

- [x] Docs/ADRs ajoutés et versionnés
- [ ] Breaking change — N/A

## Sécurité & Qualité

- [x] Typage strict OK (tsc)
- [x] Lint OK
- [x] CI verte (ci/lint, ci/typecheck, ci/test)
